### PR TITLE
Add dark mode

### DIFF
--- a/tools/docgen/header.html
+++ b/tools/docgen/header.html
@@ -111,6 +111,9 @@ limitations under the License.
               <label class="mdl-button mdl-js-button mdl-button--icon mdl-cell--hide-tablet mdl-cell--hide-phone" for="sidebar-hider">
                 <i class="material-icons">list</i>
               </label>
+                <label class="mdl-button mdl-js-button mdl-button--icon mdl-cell--hide-tablet mdl-cell--hide-phone" data-upgraded=",MaterialButton" for="theme">
+                <i class="material-icons">dark_mode</i>
+              </label>
               DOCGEN_DOCUMENT_PATH_GGFF
             </div>
             <!--Header Content-->


### PR DESCRIPTION
What needs to be done.

- [x] Add dark mode button to docgen.
- [ ] Save theme configuration to LocalStorage.
- [ ] Use the css from the main site (where possible).
- [ ] Use dark mode when devices has dark mode enabled.